### PR TITLE
Fix for OTP 21.3+.

### DIFF
--- a/lib/mariaex/connection/ssl.ex
+++ b/lib/mariaex/connection/ssl.ex
@@ -1,30 +1,7 @@
 defmodule Mariaex.Connection.Ssl do
-
   def recv(sock, bytes, timeout), do: :ssl.recv(sock, bytes, timeout)
 
-  def recv_active(sock, timeout, buffer \\ :active_once) do
-    receive do
-      {:ssl, ^sock, buffer} ->
-        {:ok, buffer}
-      {:ssl_closed, ^sock} ->
-        {:disconnect, {tag(), "async_recv", :closed, buffer}}
-      {:ssl_error, ^sock, reason} ->
-        {:disconnect, {tag(), "async_recv", reason, buffer}}
-    after
-      timeout ->
-        {:ok, <<>>}
-    end
-  end
-
   def tag(), do: :ssl
-
-  def fake_message(sock, buffer), do: {:ssl, sock, buffer}
-
-  def receive(_sock, {:ssl, _, blob}), do: blob
-
-  def setopts({:sslsocket, {:gen_tcp, sock, :tls_connection, _},_pid}, opts) do
-    :inet.setopts(sock, opts)
-  end
 
   def send(sock, data), do: :ssl.send(sock, data)
 

--- a/lib/mariaex/connection/tcp.ex
+++ b/lib/mariaex/connection/tcp.ex
@@ -19,27 +19,7 @@ defmodule Mariaex.Connection.Tcp do
 
   def recv(sock, bytes, timeout), do: :gen_tcp.recv(sock, bytes, timeout)
 
-  def recv_active(sock, timeout, buffer \\ :active_once) do
-    receive do
-      {:tcp, ^sock, buffer} ->
-        {:ok, buffer}
-      {:tcp_closed, ^sock} ->
-        {:disconnect, {tag(), "async_recv", :closed, buffer}}
-      {:tcp_error, ^sock, reason} ->
-        {:disconnect, {tag(), "async_recv", reason, buffer}}
-    after
-      timeout ->
-        {:ok, <<>>}
-    end
-  end
-
   def tag(), do: :tcp
-
-  def fake_message(sock, buffer), do: {:tcp, sock, buffer}
-
-  def receive(_sock, {:tcp, _, blob}), do: blob
-
-  def setopts(sock, opts), do: :inet.setopts(sock, opts)
 
   def send(sock, data), do: :gen_tcp.send(sock, data)
 

--- a/test/start_test.exs
+++ b/test/start_test.exs
@@ -38,10 +38,14 @@ defmodule StartTest do
                      backoff_type: :stop]
 
     Process.flag :trap_exit, true
-    assert {:error, {%Mariaex.Error{message: "failed to upgraded socket: {:tls_alert, 'unknown ca'}"}, _}} =
-      Mariaex.Connection.start_link(test_opts)
-    assert {:error, {%Mariaex.Error{message: "failed to upgraded socket: {:options, {:cacertfile, []}}"}, _}}  =
-      Mariaex.Connection.start_link(Keyword.put(test_opts, :ssl_opts, Keyword.drop(test_opts[:ssl_opts], [:cacertfile])))
+
+    {:error, %Mariaex.Error{message: message}} = Mariaex.Protocol.connect(test_opts)
+    assert message = "failed to upgraded socket: {:tls_alert, {:unknown_ca, 'received CLIENT ALERT: Fatal - Unknown CA'}}"
+
+    {:error, %Mariaex.Error{message: message}} = Mariaex.Protocol.connect(
+      Keyword.put(test_opts, :ssl_opts, Keyword.drop(test_opts[:ssl_opts], [:cacertfile]))
+    )
+    assert message = "failed to upgraded socket: {:options, {:cacertfile, []}}"
   end
 
   @tag :socket

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -67,6 +67,7 @@ cmds = [
   ~s(mysql #{mysql_connect} -e "CREATE DATABASE mariaex_test DEFAULT CHARACTER SET 'utf8' COLLATE 'utf8_general_ci';"),
   ~s(mysql #{mysql_connect} -e "#{create_user} 'mariaex_user'@'%' IDENTIFIED BY 'mariaex_pass';"),
   ~s(mysql #{mysql_connect} -e "GRANT ALL ON *.* TO 'mariaex_user'@'%' WITH GRANT OPTION"),
+  ~s(mysql #{mysql_connect} -e "FLUSH PRIVILEGES"),
   ~s(mysql --host=#{mysql_host} --port=#{mysql_port} --protocol=tcp -u mariaex_user -pmariaex_pass mariaex_test -e "#{
     sql
   }")


### PR DESCRIPTION
As of [6168cf2] in OTP 21.3, TLS/SSL sockets are active over top of
the TCP sockets. For example, when a SSL socket is in passive mode,
running an `:inet.getopts(tls_socket, [:active])` will show something
like `[active,96]`, where-in `96` refers to the fourth packet received,
starting at `100` (the default).

However, Mariaex was originally written before this `active,N`
implementation.  As such, changing the TCP socket into `active,once`
mode behaved "as expected". To my best understanding, Mariaex does this
in order to "flush" the state buffers. Of course, with the `active,N`
behaviour of SSL, once Mariaex puts the TCP socket into `active,once`,
after the next message delivery, the SSL socket becomes passive. This
seemed to create a situation where no further SSL data was made
available.

This change attempts to remove the transition into `active,once` and,
instead, tries to keep the socket passive at all times.

[6168cf2]: https://github.com/erlang/otp/commit/6168cf2f5f8b5839b1a56ce870658d76faf3c22f